### PR TITLE
fix for addon conflictions that could happen when following what the gmod wiki suggests

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -842,7 +842,10 @@ do -- with RT Cameras
 		if ( PERFRENDER_STATE ) then
 
 			local ViewSetup_t = GetViewSetup()
-			if (ViewData_t==nil) then ViewData_t=ViewSetup_t end
+
+			if ( ViewData_t == nil ) then
+				ViewData_t = ViewSetup_t
+			end
 
 			local vecViewOrigin	= ViewData_t.origin or ViewSetup_t.origin
 			local angViewAngles	= ViewData_t.angles or ViewSetup_t.angles

--- a/main.lua
+++ b/main.lua
@@ -842,6 +842,7 @@ do -- with RT Cameras
 		if ( PERFRENDER_STATE ) then
 
 			local ViewSetup_t = GetViewSetup()
+			if (ViewData_t==nil) then ViewData_t=ViewSetup_t end
 
 			local vecViewOrigin	= ViewData_t.origin or ViewSetup_t.origin
 			local angViewAngles	= ViewData_t.angles or ViewSetup_t.angles


### PR DESCRIPTION
the gmod wiki suggests running this function without any arguments, but if that happens while this addon is enabled it will flood the console with errors and break the other addon. something like this fixes it https://wiki.facepunch.com/gmod/render.RenderView#:~:text=not%20passing%20this%20table